### PR TITLE
Update to pgen v0.5 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name = "valinor",
-    version = "0.0.4",
+    version = "0.0.5",
     author = 'Martin Kojtal, Matthew Else, James Crosby',
     author_email = "c0170@rocketmail.com, matthewelse1997@gmail.com, James.Crosby@arm.com",
     description = ("Generate IDE project files to debug ELF files."),

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'setuptools',
         'colorama>=0.3,<0.4',
         'pyOCD>=0.3,<1.0',
-        'project_generator>=0.4,<1.0'
+        'project_generator>=0.5.5,<1.0'
     ],
     tests_require=[
         'nose',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'setuptools',
         'colorama>=0.3,<0.4',
         'pyOCD>=0.3,<1.0',
-        'project_generator>=0.5.5,<1.0'
+        'project_generator>=0.5.7,<1.0'
     ],
     tests_require=[
         'nose',

--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -116,11 +116,11 @@ def available():
     return [k for k in IDE_Launchers.keys()]
 
 
-def select(available_ides, target):
+def select(available_ides, target, project_settings):
     ''' select the preferred option out of the available IDEs to debug the
     selected target, or None '''
 
-    possible_ides = [x for x in available_ides if tool.target_supported(target, x)]
+    possible_ides = [x for x in available_ides if tool.target_supported(target, x, project_settings)]
 
     if len(possible_ides):
         return sorted(possible_ides, key=lambda x:IDE_Preference.index(x))[0]

--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -120,7 +120,8 @@ def select(available_ides, target, project_settings):
     ''' select the preferred option out of the available IDEs to debug the
     selected target, or None '''
 
-    possible_ides = [x for x in available_ides if tool.target_supported(target, x, project_settings)]
+    possible_ides = [x for x in available_ides if tool.target_supported(
+        tool.ToolsSupported().get_value(x, 'exporter'), target, x, project_settings)]
 
     if len(possible_ides):
         return sorted(possible_ides, key=lambda x:IDE_Preference.index(x))[0]

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -21,7 +21,7 @@ import pkg_resources
 import logging_setup
 import ide_detection
 from project_generator import tool
-from project_generator.workspace import Workspace
+from project_generator.settings import ProjectSettings
 
 def main():
     logging_setup.init()

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -70,6 +70,8 @@ def main():
 
     project_settings = ProjectSettings()
     update.update(None, False, False, project_settings)
+
+    available_ides = ide_detection.available()
     ide_tool = args.ide_tool
     if not ide_tool:
         ide_tool = ide_detection.select(available_ides, args.target, project_settings)
@@ -116,8 +118,6 @@ def main():
         'misc': [],
         'target': args.target
     }
-    workspace = Workspace(None)
-    workspace.load_definitions()
 
     exporter = tool.ToolsSupported().get_value(ide_tool, 'exporter')
     # generate debug project files (if necessary)

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -68,10 +68,12 @@ def main():
         logging.error('cannot debug file "%s" that does not exist' % args.executable)
         sys.exit(1)
 
+    project_settings = ProjectSettings()
+
     available_ides = ide_detection.available()
     ide_tool = args.ide_tool
     if not ide_tool:
-        ide_tool = ide_detection.select(available_ides, args.target)
+        ide_tool = ide_detection.select(available_ides, args.target, project_settings)
         if ide_tool is None:
             if len(available_ides):
                 logging.error('None of the detected IDEs supports "%s"', args.target)
@@ -119,7 +121,7 @@ def main():
     workspace.load_definitions()
 
     # generate debug project files (if necessary)
-    projectfile_path, projectfiles = tool.export(data, ide_tool, ProjectSettings())
+    projectfile_path, projectfiles = tool.export(data, ide_tool, project_settings)
     if projectfile_path is None:
         logging.error("failed to generate project files")
         sys.exit(1)

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -20,7 +20,7 @@ import pkg_resources
 
 import logging_setup
 import ide_detection
-from project_generator import tool
+from project_generator import tool, update
 from project_generator.settings import ProjectSettings
 
 def main():
@@ -69,8 +69,7 @@ def main():
         sys.exit(1)
 
     project_settings = ProjectSettings()
-
-    available_ides = ide_detection.available()
+    update.update(None, False, False, project_settings)
     ide_tool = args.ide_tool
     if not ide_tool:
         ide_tool = ide_detection.select(available_ides, args.target, project_settings)

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -21,7 +21,7 @@ import pkg_resources
 import logging_setup
 import ide_detection
 from project_generator import tool
-from project_generator.settings import ProjectSettings
+from project_generator.workspace import Workspace
 
 def main():
     logging_setup.init()
@@ -68,10 +68,9 @@ def main():
         logging.error('cannot debug file "%s" that does not exist' % args.executable)
         sys.exit(1)
 
-    
+    available_ides = ide_detection.available()
     ide_tool = args.ide_tool
     if not ide_tool:
-        available_ides = ide_detection.available()
         ide_tool = ide_detection.select(available_ides, args.target)
         if ide_tool is None:
             if len(available_ides):
@@ -114,9 +113,11 @@ def main():
         },
         'output_dir': os.path.relpath(executable_dir, projectfile_dir) + os.path.sep,
         'misc': [],
-        'mcu': args.target
+        'target': args.target
     }
-    
+    workspace = Workspace(None)
+    workspace.load_definitions()
+
     # generate debug project files (if necessary)
     projectfile_path, projectfiles = tool.export(data, ide_tool, ProjectSettings())
     if projectfile_path is None:

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -120,8 +120,9 @@ def main():
     workspace = Workspace(None)
     workspace.load_definitions()
 
+    exporter = tool.ToolsSupported().get_value(ide_tool, 'exporter')
     # generate debug project files (if necessary)
-    projectfile_path, projectfiles = tool.export(data, ide_tool, project_settings)
+    projectfile_path, projectfiles = tool.export(exporter, data, ide_tool, project_settings)
     if projectfile_path is None:
         logging.error("failed to generate project files")
         sys.exit(1)
@@ -129,7 +130,7 @@ def main():
     # perform any modifications to the executable itself that are necessary to
     # debug it (for example, to debug an ELF with Keil uVision, it must be
     # renamed to have the .axf extension)
-    executable = tool.fixup_executable(args.executable, ide_tool)
+    executable = tool.fixup_executable(exporter, args.executable, ide_tool)
 
     if args.start_session:
         launch_fn = ide_detection.get_launcher(ide_tool)


### PR DESCRIPTION
Project generator got an update to v0.5 today. Target definitions are external, currently there's only frdm-k64f defined. As mbed uses k64f as the target name, we'll will need to add k64f target to definitions.
Tested with uvision (windows), we should test this with all tool supported (gdb, arm gdb and uvision). 

We should leave this PR open (although req version is still v0.4), until k64f is added to definitions plus test results provided for all tools plus other OS.

