### PR TITLE
Update for pgen v0.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'setuptools',
         'colorama>=0.3,<0.4',
         'pyOCD>=0.3,<1.0',
-        'project_generator>=0.7.0,<=0.8.0'
+        'project_generator>=0.7.0,<0.8.0'
     ],
     tests_require=[
         'nose',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'setuptools',
         'colorama>=0.3,<0.4',
         'pyOCD>=0.3,<1.0',
-        'project_generator>=0.5.7,<0.6.0'
+        'project_generator>=0.7.0,<=0.8.0'
     ],
     tests_require=[
         'nose',

--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -10,7 +10,7 @@ import os
 
 from distutils.spawn import find_executable
 
-from project_generator import targets, tools_supported, targets
+from project_generator import targets, tools_supported
 
 from gdb import launcher as gdb_launcher
 from gdb import arm_none_eabi_launcher as arm_none_eabi_gdb_launcher

--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -123,7 +123,7 @@ def select(available_ides, target, project_settings):
     for ide in available_ides:
         tool = tools_supported.ToolsSupported().get_tool(ide)
         if not tool.is_supported_by_default(target):
-            if targets.Targets(project_settings.get_env_settings('definitions')).is_supported(target, tool):
+            if targets.Targets(project_settings.get_env_settings('definitions')).is_supported(target, ide):
                 possible_ides.append(ide)
         else:
             possible_ides.append(ide)

--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -10,7 +10,7 @@ import os
 
 from distutils.spawn import find_executable
 
-from project_generator import tool
+from project_generator import targets, tools_supported, targets
 
 from gdb import launcher as gdb_launcher
 from gdb import arm_none_eabi_launcher as arm_none_eabi_gdb_launcher
@@ -119,9 +119,14 @@ def available():
 def select(available_ides, target, project_settings):
     ''' select the preferred option out of the available IDEs to debug the
     selected target, or None '''
-
-    possible_ides = [x for x in available_ides if tool.target_supported(
-        tool.ToolsSupported().get_value(x, 'exporter'), target, x, project_settings)]
+    possible_ides = []
+    for ide in available_ides:
+        tool = tools_supported.ToolsSupported().get_tool(ide)
+        if not tool.is_supported_by_default(target):
+            if targets.Targets(project_settings.get_env_settings('definitions')).is_supported(target, tool):
+                possible_ides.append(ide)
+        else:
+            possible_ides.append(ide)
 
     if len(possible_ides):
         return sorted(possible_ides, key=lambda x:IDE_Preference.index(x))[0]

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -69,7 +69,7 @@ def main():
         sys.exit(1)
 
     project_settings = ProjectSettings()
-    update.update(None, False, False, project_settings)
+    update.update(False, project_settings)
 
     available_ides = ide_detection.available()
     ide_tool = args.ide_tool
@@ -102,6 +102,7 @@ def main():
         'name': file_base_name,     # project name
         'core': '',                 # core
         'linker_file': '',          # linker command file
+        'build_dir' : 'source',
         'include_paths': [],        # include paths
         'source_paths': [],         # source paths
         'source_files_c': [],       # c source files
@@ -114,7 +115,10 @@ def main():
             'name': '.' + os.path.sep,
             'path' : projectfile_dir
         },
-        'output_dir': os.path.relpath(executable_dir, projectfile_dir) + os.path.sep,
+        'output_dir': {
+            'rel_path' : '',
+            'path' : os.path.relpath(executable_dir, projectfile_dir) + os.path.sep,
+        },
         'misc': [],
         'target': args.target
     }

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -102,7 +102,7 @@ def main():
         'name': file_base_name,     # project name
         'core': '',                 # core
         'linker_file': '',          # linker command file
-        'build_dir' : 'source',
+        'build_dir' : projectfile_dir,
         'include_paths': [],        # include paths
         'source_paths': [],         # source paths
         'source_files_c': [],       # c source files

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -109,8 +109,8 @@ def main():
         'source_files_c': [],       # c source files
         'source_files_cpp': [],     # c++ source files
         'source_files_s': [],       # assembly source files
-        'source_files_obj': [],     # object files
-        'source_files_lib': [],     # libraries
+        'source_files_obj': [{}],   # object files
+        'source_files_lib': [{}],   # libraries
         'macros': [],               # macros (defines)
         'project_dir': {
             'name': '.' + os.path.sep,
@@ -120,8 +120,9 @@ def main():
             'rel_path' : '',
             'path' : os.path.relpath(executable_dir, projectfile_dir) + os.path.sep,
         },
-        'misc': [],
-        'target': args.target
+        'target': args.target,  # target
+        'template' : '',        # tool template
+        'output_type': 'exe',   # output type, default to exe
     }
 
     exporter = tool.ToolsSupported().get_value(ide_tool, 'exporter')

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -21,9 +21,8 @@ import shutil
 
 import logging_setup
 import ide_detection
-from project_generator import tool
 from project_generator.project import Project
-from project_generator.workspace import PgenWorkspace
+from project_generator.generate import Generator
 from project_generator.settings import ProjectSettings
 
 def main():
@@ -117,7 +116,7 @@ def main():
     projects = {
         'projects' : {}
     }
-    project = Project(file_base_name, [project_data], PgenWorkspace(projects))
+    project = Project(file_base_name, [project_data], Generator(projects))
     project.export(ide_tool, False)
 
     # perform any modifications to the executable itself that are necessary to

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -17,6 +17,7 @@ import argparse
 import os
 import sys
 import pkg_resources
+import shutil
 
 import logging_setup
 import ide_detection
@@ -123,7 +124,11 @@ def main():
     # perform any modifications to the executable itself that are necessary to
     # debug it (for example, to debug an ELF with Keil uVision, it must be
     # renamed to have the .axf extension)
-    executable = project.fixup_executable(args.executable, ide_tool)
+    executable = args.executable
+    if ide_tool == 'uvision':
+        new_exe_path = args.executable + '.axf'
+        shutil.copy(args.executable, new_exe_path)
+        executable = new_exe_path
     projectfiles = project.get_generated_project_files(ide_tool)
     if not projectfiles:
         logging.error("failed to generate project files")

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -103,10 +103,10 @@ def main():
     project_data = {
         'common': {
             'target': [args.target],  # target
-            'build_dir': [projectfile_dir],
+            'build_dir': [''],
             'debugger': ['cmsis-dap'],   # TODO: find out what debugger is connected
             'linker_file': ['None'],
-            'export_dir': [projectfile_dir],
+            'export_dir': ['.' + os.path.sep + projectfile_dir],
             'output_dir': {
                 'rel_path' : [''],
                 'path' : [os.path.relpath(executable_dir, projectfile_dir) + os.path.sep],

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -21,7 +21,7 @@ import shutil
 
 import logging_setup
 import ide_detection
-from project_generator import tool, update
+from project_generator import tool
 from project_generator.project import Project
 from project_generator.workspace import PgenWorkspace
 from project_generator.settings import ProjectSettings
@@ -72,7 +72,6 @@ def main():
         sys.exit(1)
 
     project_settings = ProjectSettings()
-    update.update(False, project_settings)
 
     available_ides = ide_detection.available()
     ide_tool = args.ide_tool

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -103,7 +103,8 @@ def main():
         'core': '',                 # core
         'linker_file': '',          # linker command file
         'build_dir' : projectfile_dir,
-        'include_paths': [],        # include paths
+        'debugger' : 'cmsis-dap',   # TODO: find out what debugger is connected
+        'includes': [],             # include paths
         'source_paths': [],         # source paths
         'source_files_c': [],       # c source files
         'source_files_cpp': [],     # c++ source files

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -86,7 +86,7 @@ def main():
     if ide_tool is None:
         logging.error(
             'No IDE tool available for target "%s". Please see '+
-            'https://github.com/0xc0170/project_generator for details '+
+            'https://github.com/project-generator/project_generator for details '+
             'on adding support.', args.target
         )
         sys.exit(1)

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -137,10 +137,10 @@ def main():
     if args.start_session:
         launch_fn = ide_detection.get_launcher(ide_tool)
         if launch_fn is not None:
-            launch_fn(projectfiles, executable)
+            launch_fn(projectfiles['files'], executable)
         else:
             logging.warning('failed to open IDE')
-            print 'project files have been generated in:', os.path.normpath(projectfile_path)
+            print 'project files have been generated in:', os.path.normpath(projectfiles['path'])
     else:
-        print 'project files have been generated in:', os.path.normpath(projectfile_path)
+        print 'project files have been generated in:', os.path.normpath(projectfiles['path'])
 

--- a/valinor/test/test_exporter.py
+++ b/valinor/test/test_exporter.py
@@ -16,10 +16,10 @@ from nose.tools import *
 from os.path import abspath
 import sys
 
-from project_generator.builders.builder import Builder
+from project_generator.tools.builder import Builder
 
 # Makes sure that exporting using generic builder will fail.
 @raises(NotImplementedError)
 def test_exporter_location():
     b = Builder()
-    b.build_project('', '')
+    b.build_project()

--- a/valinor/test/test_exporter.py
+++ b/valinor/test/test_exporter.py
@@ -16,7 +16,7 @@ from nose.tools import *
 from os.path import abspath
 import sys
 
-from project_generator.tools.builder import Builder
+from project_generator.tools.tool import Builder
 
 # Makes sure that exporting using generic builder will fail.
 @raises(NotImplementedError)


### PR DESCRIPTION
I would like to keep this open for a while, for people to test. I'll have few more patches in the queue for pgen v0.6 anyway, which I'll test with valinor.

There's now debugger setting, which I set to cmsis-dap by default. I have one target - silabs giant gecko which has j-link on board. How can we propagate this info to pgen to set jlink in the exported project file?

```
'debugger' : 'cmsis-dap',   # TODO: find out what debugger is connected
```