### PR TITLE
show full path to generated project files 

### DIFF
--- a/valinor/main.py
+++ b/valinor/main.py
@@ -147,5 +147,5 @@ def main():
                 logging.error('failed to launch debugger: %s', e)
         else:
             logging.warning('failed to open IDE')
-    print('project files have been generated in: %s' % os.path.normpath(projectfiles['path']))
+    print('project files have been generated in: %s' % os.path.join(os.getcwd(), os.path.normpath(projectfiles['path'])))
 


### PR DESCRIPTION
(it's relative to the CWD which may have been changed by yotta before running valinor)