### PR TITLE
Fix build dir + sort sources

### DIFF
--- a/valinor/main.py
+++ b/valinor/main.py
@@ -118,7 +118,7 @@ def main():
                 'rel_path' : [''],
                 'path' : [os.path.relpath(executable_dir, projectfile_dir) + os.path.sep],
             },
-            'sources': {'Source_Files':[f for f in files]},
+            'sources': {'Source_Files':sorted([f for f in files], key=lambda file: os.path.basename(file))},
         }
     }
 

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -110,7 +110,7 @@ def main():
     project_data = {
         'common': {
             'target': [args.target],  # target
-            'build_dir': [''],
+            'build_dir': ['.'],
             'debugger': ['cmsis-dap'],   # TODO: find out what debugger is connected
             'linker_file': ['None'],
             'export_dir': ['.' + os.path.sep + projectfile_dir],


### PR DESCRIPTION
Latest patch in progen (v0.8.6) fixed None values coming from yaml parsing, this leads to build_dir not picked up as its empty string (= not valid). This should fix it. This should not cause any regression (I tested it with 0.8.5 (None are valid there), and 0.8.6).

Plus I added sorting sources, however this requires a fix on the progen side. I created an issue for progen, will have a look how to fix it. The idea is to have files in the workspace IDE sorted by name. It's hard to navigate now.