### PR TITLE
progen data - remove default debugger

### DIFF
--- a/valinor/main.py
+++ b/valinor/main.py
@@ -111,7 +111,6 @@ def main():
         'common': {
             'target': [args.target],  # target
             'build_dir': ['.'],
-            'debugger': ['cmsis-dap'],   # TODO: find out what debugger is connected
             'linker_file': ['None'],
             'export_dir': ['.' + os.path.sep + projectfile_dir],
             'output_dir': {


### PR DESCRIPTION
If we set it, it overrides the target one, as it has higher priority.
The target should set the debugger (platform does, not mcu). If there's
no debugger (=mcu used as --target), then use default, for uvision is
cmsis-dap for instance. This should not cause the regression.

As there was todo which debugger is connected, that one can come later and would overwrite the target/default one.