### PR TITLE
IDE detection: add uvision5

### DIFF
--- a/valinor/ide_detection.py
+++ b/valinor/ide_detection.py
@@ -25,7 +25,7 @@ IDEs_Scanned = False
 
 # preferred order of IDEs if multiple are available
 IDE_Preference = [
-    'uvision', 'arm_none_eabi_gdb', 'gdb'
+    'uvision', 'uvision5', 'arm_none_eabi_gdb', 'gdb'
 ]
 
 
@@ -86,6 +86,7 @@ def _uvision_launcher(uvision_exe):
 
 IDE_Scanners = {
               'uvision': (_find_uvision, _uvision_launcher),
+             'uvision5': (_find_uvision, _uvision_launcher),
                   'gdb': (_find_generic_gdb, gdb_launcher),
     'arm_none_eabi_gdb': (_find_arm_none_eabi_gdb, arm_none_eabi_gdb_launcher),
 }
@@ -142,4 +143,3 @@ def get_launcher(ide):
         return IDE_Launchers[ide]
     else:
         return None
-

--- a/valinor/main.py
+++ b/valinor/main.py
@@ -128,7 +128,7 @@ def main():
     # debug it (for example, to debug an ELF with Keil uVision, it must be
     # renamed to have the .axf extension)
     executable = args.executable
-    if ide_tool == 'uvision':
+    if ide_tool in ('uvision', 'uvision5'):
         new_exe_path = args.executable + '.axf'
         shutil.copy(args.executable, new_exe_path)
         executable = new_exe_path
@@ -147,4 +147,3 @@ def main():
         else:
             logging.warning('failed to open IDE')
     print('project files have been generated in: %s' % os.path.join(os.getcwd(), os.path.normpath(projectfiles['path'])))
-


### PR DESCRIPTION
This patch adds the support for uvision5 into the IDE detection
Valinor module.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@arm.com>