### PR TITLE
Remove YAML/Jinja2 dependencies from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ setup(
     },
     test_suite = 'nose.collector',
     install_requires=[
-        'pyyaml>=5.1,<6.0',
-        'Jinja2>=2.7.0,<3',
         'setuptools',
         'colorama>=0.3,<0.4',
         'pyOCD>=0.3,<1.0',


### PR DESCRIPTION
I can see no code using YAML or Jinja2 in the current valinor codebase.

A review of the commit history suggests that the YAML/Jinja2 dependencies declared in setup.py became redundant in commit 859706f2918c9161abd223fb0638d7f30a8199fb when the project_generator code was removed and spun out into a separate project.